### PR TITLE
Refactored scrape

### DIFF
--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -7,7 +7,7 @@ class TournamentsController < ApplicationController
   skip_before_action :authenticate_user!, only: %i[index show]
 
   def index
-    all_crosstables_events
+    # all_crosstables_events # Commenting this out so it's not called every page load
     @events = Event.all
     @tournament = Tournament.new
     @tournaments = policy_scope(Tournament)
@@ -46,22 +46,30 @@ class TournamentsController < ApplicationController
     url = 'https://www.cross-tables.com'
     html = URI.open(url)
     doc = Nokogiri::HTML(html)
-    tournaments = doc.css('#utblock .xtdatatable tr')
+    # Find all tags that use the "rowupcoming#" id. This is the CSS id used for
+    # each row in the upcoming events table.
+    tournaments = doc.xpath('//tr[starts-with(@id, "rowupcoming")]')
 
     tournaments.each_with_index do |tournament, index|
-      if index.positive? && index < tournaments.count - 2
-        naspa = tournament.css('img').attribute('src').value == 'i/naspa.png'
-        if naspa
-          @location = tournament.css('a').children.text
-          # May want to use this date method below to get the tournament's start date
-          # So that we can sort upcoming events by start date
-          month_and_day = tournament.css('td')[-2].children.text[/^\d*\/\d*/]
-          year = tournament.css('td')[-2].children.text[/\d\d\d\d/] || Date.today.year
-          @sortable_date = Date.parse("#{year}/#{month_and_day}")
+      # Check if it's a NASPA event
+      naspa = tournament.css('img').attribute('src').value == 'i/naspa.png'
 
-          tournament.css('span').children.each do |event|
-            create_event(event)
-          end
+      # If it's a NASPA event, get its date and location, and create a new
+      # record for that event
+      if naspa
+        @location = tournament.css('a').children.text
+
+        # May want to use this date method below to get the tournament's start
+        # date so that we can sort upcoming events by start date
+        # TODO: Fix the month_and_day regex to grab date ranges. Currently,
+        #       multi-day events are setting each event on the first day. Check
+        #       Kingston, as an example
+        month_and_day = tournament.css('td')[-2].children.text[/^\d*\/\d*/]
+        year = tournament.css('td')[-2].children.text[/\d{4}/] || Date.today.year
+        @sortable_date = Date.parse("#{year}/#{month_and_day}")
+
+        tournament.css('span').children.each do |event|
+          create_event(event)
         end
       end
     end
@@ -71,14 +79,20 @@ class TournamentsController < ApplicationController
     url = "https://www.cross-tables.com#{event.attribute('href').value}"
     html = URI.open(url)
     doc = Nokogiri::HTML(html)
+
     # This returns a string date, since often the date is a range,
     # which is not easy to parse into a Date object. See above
     date = doc.css('p').children[2].text[/\w.*20\d\d/]
-    xtables_id = event.attribute('href').value[/\d\d\d\d\d$/].to_i
+    xtables_id = event.attribute('href').value[/\d+$/].to_i
     number_of_players = doc.css('p').children[8].text.to_i
-    number_of_games = doc.css('td').children.text[/games:.\d*/][/\d+/]
+    rounds = doc.css('td').children.text[/games:.\d*/][/\d+/]
 
-    Event.create!(location: @location, rounds: number_of_games, number_of_players: number_of_players, date: @sortable_date, xtables_id: xtables_id) unless Event.find_by(xtables_id: xtables_id)
+    Event.create!(
+      location: @location,
+      rounds: rounds,
+      number_of_players: number_of_players,
+      date: @sortable_date,
+      xtables_id: xtables_id) unless Event.find_by(xtables_id: xtables_id)
   end
 
   def set_tournament

--- a/app/views/tournaments/_form.html.erb
+++ b/app/views/tournaments/_form.html.erb
@@ -1,6 +1,8 @@
-  <%= simple_form_for tournament do |f| %>
-    <%= f.input :pairing_system, collection: ['swiss', 'round_robin', 'KOTH'] %>
-    <%= f.input :number_of_winners %>
-    <%= f.button :submit %>
-    <%= f.hidden_field :event, value: event.id %>
-  <% end %>
+<div class="d-flex">
+    <%= simple_form_for tournament do |f| %>
+      <%= f.input :pairing_system, collection: ['swiss', 'round_robin', 'KOTH'] %>
+      <%= f.input :number_of_winners %>
+      <%= f.button :submit, class: "btn btn-outline-primary" %>
+      <%= f.hidden_field :event, value: event.id %>
+    <% end %>
+</div>

--- a/app/views/tournaments/index.html.erb
+++ b/app/views/tournaments/index.html.erb
@@ -1,7 +1,12 @@
-<% @events.each do |event| %>
-  <h3><%= event.location %></h3>
-  <p><%= event.date %></p>
-  <p><%= event.rounds %> games</p>
-  <p><%= event.number_of_players %> players</p>
-  <%= render "form", tournament: @tournament, event: event %>
-<% end %>
+<div class="container d-flex flex-wrap justify-content-around">
+  <% @events.each do |event| %>
+    <%# event-card class does nothing now, but should be created in our CSS %>
+    <div class="col-4 mb-5 event-card">
+      <h4><%= event.location %></h4>
+      <p><%= event.date %></p>
+      <p><%= event.rounds %> games</p>
+      <p><%= event.number_of_players || "0" %> players</p>
+      <%= render "form", tournament: @tournament, event: event %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/tournaments/show.html.erb
+++ b/app/views/tournaments/show.html.erb
@@ -6,7 +6,7 @@
     <p>Date: <%= @tournament.date.strftime('%B %e, %Y') %></p>
     <p>Number of rounds: <%= @tournament.rounds %></p>
     <p>Number of winners:
-      <%= @tournament.number_of_winners.nil? ? "unknown" : @tournament.number_of_winners %>
+      <%= @tournament.number_of_winners || "unknown" %>
     </p>
     <p>Pairing system: <%= @tournament.pairing_system.capitalize %></p>
   </div>


### PR DESCRIPTION
In the `all_crosstables_events` method, I targeted the rows more specifically, and removed some unnecessary conditionals. Also touched up some regex stuff.

Temporarily commented-out the call to scrape in the index action, since that makes page-loads too long. That will need to be added as an automated task instead.

Some basic style changes to the index and form, just to help see stuff a bit easier. These changes are temporary until they're properly styled.

![image](https://user-images.githubusercontent.com/48395382/203678481-ec8eb699-2929-4d60-b739-73bdd9ab4839.png)
