### PR TITLE
Some bugfixes in the tournament view

### DIFF
--- a/app/controllers/matchups_controller.rb
+++ b/app/controllers/matchups_controller.rb
@@ -1,7 +1,7 @@
 class MatchupsController < ApplicationController
-  before_action :set_matchup, only: %i[edit update]
+  before_action :set_matchup, only: %i[set_score update]
 
-  def edit
+  def set_score
   end
 
   def update

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -7,7 +7,7 @@ class Tournament < ApplicationRecord
   # TODO: Possibly need a validation for number_of_winners, but low priority
 
   enum pairing_system: {
-    swiss: 10,
-    round_robin: 20
+    "Swiss" => 10,
+    "round-robin" => 20
   }
 end

--- a/app/policies/matchup_policy.rb
+++ b/app/policies/matchup_policy.rb
@@ -6,12 +6,12 @@ class MatchupPolicy < ApplicationPolicy
     # end
   end
 
-  def edit?
-    update?
-  end
-
   def update?
     user_is_owner?
+  end
+
+  def set_score?
+    update?
   end
 
   private

--- a/app/views/matchups/set_score.html.erb
+++ b/app/views/matchups/set_score.html.erb
@@ -8,8 +8,8 @@
     <%= f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present? %>
 
     <div class="form-inputs">
-      <%= f.input :player1_score, label: "#{@matchup.player1.name} score" %>
-      <%= f.input :player2_score, label: "#{@matchup.player2.name} score" %>
+      <%= f.input :player1_score, label: "#{@matchup.player1.name}:" %>
+      <%= f.input :player2_score, label: "#{@matchup.player2.name}:" %>
     </div>
 
     <%= f.submit "Submit score", class: "btn btn-primary" %>

--- a/app/views/tournaments/_form.html.erb
+++ b/app/views/tournaments/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="d-flex">
     <%= simple_form_for tournament do |f| %>
-      <%= f.input :pairing_system, collection: ['swiss', 'round_robin', 'KOTH'] %>
+      <%= f.input :pairing_system, collection: Tournament.pairing_systems.keys, include_blank: false %>
       <%= f.input :number_of_winners %>
       <%= f.button :submit, class: "btn btn-outline-primary w-100" %>
       <%= f.hidden_field :event, value: event.id %>

--- a/app/views/tournaments/show.html.erb
+++ b/app/views/tournaments/show.html.erb
@@ -6,20 +6,33 @@
     <p>Date: <%= @tournament.event.date.strftime('%B %e, %Y') ||
       @tournament.date.strftime('%B %e, %Y')
     %></p>
-    <p>Number of rounds: <%= @tournament.rounds %></p>
+    <p>Number of rounds: <%= @tournament.rounds || "unknown" %></p>
     <p>Number of winners:
       <%= @tournament.number_of_winners || "unknown" %>
     </p>
-    <p>Pairing system: <%= @tournament.pairing_system.capitalize %></p>
+    <p>Pairing system: <%= @tournament.pairing_system %></p>
   </div>
 
   <div class="mb-3 border-bottom border-3">
     <p>Players</p>
     <ul>
-      <% @tournament.players.each do |player| %>
-        <li><%= player.name %></li>
+      <% if @tournament.players.nil? %>
+        <div>No players added yet in Pairwise</div>
+      <% else %>
+        <% @tournament.players.each do |player| %>
+          <li><%= player.name %></li>
+        <% end %>
       <% end %>
     </ul>
+    <div>
+      <% if @tournament.user == current_user %>
+        <div>
+          <%# TODO: When making the Add Players route, replace this link %>
+          <%= link_to "Add players", "#",
+            class: "btn btn-sm btn-outline-primary" %>
+        </div>
+      <% end %>
+    </div>
   </div>
 
   <%# TODO: Make this into a partial.
@@ -30,24 +43,28 @@
             page, but that might get tricky.
             https://kitt.lewagon.com/knowledge/tutorials/inline_edit
   %>
-  <div class="mb-3 border-bottom border-3">
-    <p>Rounds</p>
-    <ul class="mb-3">
+  <div class="border">
+    <h5>Rounds</h5>
+    <ul class="">
       <% @tournament.matchups.each do |matchup| %>
-        <li class="d-flex justify-content-between col-5 border-bottom align-items-center">
-          <div>
-            Round <%= matchup.round_number %>:
-            <div class="px-2">
-              <%= matchup.player1.name %>
-              (<%= matchup.player1_score.nil? ? "0" : matchup.player1_score %>) :
-              <%= matchup.player2.name %>
-              (<%= matchup.player2_score.nil? ? "0" : matchup.player2_score %>)
-            </div>
-          </div>
-          <div>
-            <%= link_to "Set score", edit_matchup_path(matchup),
-              class: "btn btn-sm btn-outline-primary" %>
-          </div>
+        <li class="">
+          Round <%= matchup.round_number %>:
+          <%= matchup.player1.name %>
+          (<%= matchup.player1_score.nil? ? "0" : matchup.player1_score %>) :
+          <%= matchup.player2.name %>
+          (<%= matchup.player2_score.nil? ? "0" : matchup.player2_score %>)
+
+          <% round_not_started = matchup.player1_score.nil? && matchup.player2_score.nil? %>
+          <% if @tournament.user == current_user %>
+            <%= link_to "Set score", set_score_path(matchup),
+              class: "btn btn-sm btn-outline-success" %>
+
+            <%# TODO: When making the Edit Pairing route, replace this link %>
+            <% if round_not_started %>
+              <%= link_to "Edit pairing", "#",
+                class: "btn btn-sm btn-outline-danger" %>
+            <% end %>
+          <% end %>
         </li>
       <% end %>
     </ul>

--- a/app/views/tournaments/show.html.erb
+++ b/app/views/tournaments/show.html.erb
@@ -44,7 +44,7 @@
             https://kitt.lewagon.com/knowledge/tutorials/inline_edit
   %>
   <div class="border">
-    <h5>Rounds</h5>
+    <p>Rounds</p>
     <ul class="">
       <% @tournament.matchups.each do |matchup| %>
         <li class="">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,8 @@ Rails.application.routes.draw do
 
   resources :tournaments, only: %i[index new create show]
 
-  resources :matchups, only: %i[edit update]
+  resources :matchups, only: %i[update]
+  get "/matchups/:id/set_score", to: "matchups#set_score", as: :set_score
 
   get "/contact", to: "pages#contact_us", as: :contact_us
   get "/profile", to: "pages#my_profile", as: :my_profile


### PR DESCRIPTION
Made some changes to control which links can be seen in the Show Tournament page. The Add Players, Set Score, and Edit Pairings links have conditionals, so only the tourney owner can see them. Additionally, Edit Pairings can only be done if a score hasn't been set yet.

![image](https://user-images.githubusercontent.com/48395382/203850552-0a754b22-514a-4660-83e6-af96059aea12.png)

The enum names were renamed to what we would want them to show up as in the view.

The edit matchups route was changed to set_score to be more specific.

Added "unknown" in the view when we don't know the number of rounds