### PR TITLE
Fix bug for byes

### DIFF
--- a/app/controllers/matchups_controller.rb
+++ b/app/controllers/matchups_controller.rb
@@ -111,7 +111,19 @@ class MatchupsController < ApplicationController
 
     # create matchups based on the pairings
     pairings.each do |pairing|
-      Matchup.create!(round_number: round, player1: pairing[0], player2: pairing[1])
+      if pairing.include?(Swissper::Bye)
+        # This logic was breaking, and I realize it is easier to not generate a matchup at all
+        # and have a bye be another boolean for a player
+        # real_player_id = 1 - pairing.find_index(Swissper::Bye)
+        # if Player.where(tournament: pairing[real_player_id].tournament, name: "Bye").empty?
+        #   bye = Player.create!(name: "Bye", tournament: pairing[real_player_id].tournament, rating: 0, division: div, win_count: 0)
+        # else
+        #   bye = Player.where(tournament: pairing[real_player_id].tournament, name: "Bye")
+        # end
+        # Matchup.create!(round_number: round, player1: pairing[real_player_id], player2: bye)
+      else
+        Matchup.create!(round_number: round, player1: pairing[0], player2: pairing[1])
+      end
     end
   end
 

--- a/app/controllers/matchups_controller.rb
+++ b/app/controllers/matchups_controller.rb
@@ -112,13 +112,12 @@ class MatchupsController < ApplicationController
     # create matchups based on the pairings
     pairings.each do |pairing|
       if pairing.include?(Swissper::Bye)
-        # This logic was breaking, and I realize it is easier to not generate a matchup at all
-        # and have a bye be another boolean for a player
-        # real_player_id = 1 - pairing.find_index(Swissper::Bye)
+
+        real_player_id = 1 - pairing.find_index(Swissper::Bye)
         # if Player.where(tournament: pairing[real_player_id].tournament, name: "Bye").empty?
         #   bye = Player.create!(name: "Bye", tournament: pairing[real_player_id].tournament, rating: 0, division: div, win_count: 0)
         # else
-        #   bye = Player.where(tournament: pairing[real_player_id].tournament, name: "Bye")
+        #   bye = Player.find_by(tournament: pairing[real_player_id].tournament, name: "Bye")
         # end
         # Matchup.create!(round_number: round, player1: pairing[real_player_id], player2: bye)
       else

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -199,8 +199,7 @@ class TournamentsController < ApplicationController
     pairings[:round_1].each do |div, pairings|
       pairings.each do |pairing|
         if pairing.include?(Swissper::Bye)
-
-          # real_player_id = 1 - pairing.find_index(Swissper::Bye)
+          real_player_id = 1 - pairing.find_index(Swissper::Bye)
           # bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div)
           # Matchup.create!(round_number: 1, player1: pairing[real_player_id], player2: bye)
         else
@@ -214,8 +213,8 @@ class TournamentsController < ApplicationController
       pairings.each do |pairing|
         if pairing.include?(Swissper::Bye)
           real_player_id = 1 - pairing.find_index(Swissper::Bye)
-          bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div, win_count: 0)
-          Matchup.create!(round_number: 2, player1: pairing[real_player_id], player2: bye)
+          # bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div, win_count: 0)
+          # Matchup.create!(round_number: 2, player1: pairing[real_player_id], player2: bye)
         else
           Matchup.create!(round_number: 2, player1: pairing[0], player2: pairing[1])
         end

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -199,9 +199,10 @@ class TournamentsController < ApplicationController
     pairings[:round_1].each do |div, pairings|
       pairings.each do |pairing|
         if pairing.include?(Swissper::Bye)
-          real_player_id = 1 - pairing.find_index(Swissper::Bye)
-          bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div)
-          Matchup.create!(round_number: 1, player1: pairing[real_player_id], player2: bye)
+
+          # real_player_id = 1 - pairing.find_index(Swissper::Bye)
+          # bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div)
+          # Matchup.create!(round_number: 1, player1: pairing[real_player_id], player2: bye)
         else
           Matchup.create!(round_number: 1, player1: pairing[0], player2: pairing[1])
         end
@@ -213,7 +214,7 @@ class TournamentsController < ApplicationController
       pairings.each do |pairing|
         if pairing.include?(Swissper::Bye)
           real_player_id = 1 - pairing.find_index(Swissper::Bye)
-          bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div)
+          bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div, win_count: 0)
           Matchup.create!(round_number: 2, player1: pairing[real_player_id], player2: bye)
         else
           Matchup.create!(round_number: 2, player1: pairing[0], player2: pairing[1])

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -198,14 +198,27 @@ class TournamentsController < ApplicationController
     # Generate matchups for round 1 based on pairings
     pairings[:round_1].each do |div, pairings|
       pairings.each do |pairing|
-        Matchup.create!(round_number: 1, player1: pairing[0], player2: pairing[1])
+        if pairing.include?(Swissper::Bye)
+          real_player_id = 1 - pairing.find_index(Swissper::Bye)
+          bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div)
+          Matchup.create!(round_number: 1, player1: pairing[real_player_id], player2: bye)
+        else
+          Matchup.create!(round_number: 1, player1: pairing[0], player2: pairing[1])
+        end
       end
     end
 
     # Generate matchups for round 2 based on pairings
     pairings[:round_2].each do |div, pairings|
       pairings.each do |pairing|
-        Matchup.create!(round_number: 2, player1: pairing[0], player2: pairing[1])
+        if pairing.include?(Swissper::Bye)
+          real_player_id = 1 - pairing.find_index(Swissper::Bye)
+          bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div)
+          Matchup.create!(round_number: 2, player1: pairing[real_player_id], player2: bye)
+        else
+          Matchup.create!(round_number: 2, player1: pairing[0], player2: pairing[1])
+        end
+
       end
     end
   end


### PR DESCRIPTION
This fixed the bug for byes, so now we can start tournaments that have an odd number of players, but I will have to implement more robust logic later to:
a) display people as having a bye in the pairings/scoreboard
b) give an auto-win and +50 spread to a player with a bye