### PR TITLE
fix an alignment issue with long names

### DIFF
--- a/app/assets/stylesheets/components/_scoreboard_player_card.scss
+++ b/app/assets/stylesheets/components/_scoreboard_player_card.scss
@@ -97,6 +97,7 @@
   display: flex;
   // border: solid red;
   justify-content: center;
+  text-align: center;
   font-size: 24px;
 }
 


### PR DESCRIPTION
Name isn't centered
![image](https://user-images.githubusercontent.com/48395382/204666199-fe0a6c8f-4696-42b1-839c-5d7ce025c979.png)

Fix:
![image](https://user-images.githubusercontent.com/48395382/204666239-6c41fcc1-297f-41fa-9e68-f4fdcbeca4e1.png)
