### PR TITLE
Make the Tournaments link visible in the navbar when logged out

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -10,10 +10,10 @@
 
     <div class="collapse navbar-collapse" id="navbarSupportedContent">
       <ul class="navbar-nav me-auto">
+        <li class="nav-item">
+          <%= link_to "Tournaments", tournaments_path, class: "nav-link" %>
+        </li>
         <% if user_signed_in? %>
-          <li class="nav-item">
-            <%= link_to "Tournaments", tournaments_path, class: "nav-link" %>
-          </li>
           <% if current_user.tournaments.present? %>
             <li class="nav-item">
               <%= link_to "My Tournaments", my_tournaments_path, class: "nav-link" %>


### PR DESCRIPTION
Consistency with the footer

![image](https://user-images.githubusercontent.com/48395382/204834876-53ce35e5-619d-4752-a656-b5d863f870fe.png)
