### PR TITLE
Generate matchup for new player and implemented Bye logic

### DIFF
--- a/app/controllers/matchups_controller.rb
+++ b/app/controllers/matchups_controller.rb
@@ -74,7 +74,7 @@ class MatchupsController < ApplicationController
 
       # Find all players in the division and determine which round to generate
       # pairings for
-      players = player1.tournament.players.select { |player| player.division == player1.division}
+      players = player1.tournament.players.select { |player| player.division == player1.division && player.name != "Bye"}
       round_to_generate = @matchup.round_number + 2
       generate_matchups(round_to_generate, players) if player1.tournament.event.rounds >= round_to_generate && matchups_without_scores.empty?
 

--- a/app/controllers/matchups_controller.rb
+++ b/app/controllers/matchups_controller.rb
@@ -117,12 +117,12 @@ class MatchupsController < ApplicationController
       if pairing.include?(Swissper::Bye)
 
         real_player_id = 1 - pairing.find_index(Swissper::Bye)
-        # if Player.where(tournament: pairing[real_player_id].tournament, name: "Bye").empty?
-        #   bye = Player.create!(name: "Bye", tournament: pairing[real_player_id].tournament, rating: 0, division: div, win_count: 0)
-        # else
-        #   bye = Player.find_by(tournament: pairing[real_player_id].tournament, name: "Bye")
-        # end
-        # Matchup.create!(round_number: round, player1: pairing[real_player_id], player2: bye)
+        if Player.where(tournament: pairing[real_player_id].tournament, name: "Bye").empty?
+          bye = Player.create!(name: "Bye", tournament: pairing[real_player_id].tournament, rating: 0, division: div, win_count: 0)
+        else
+          bye = Player.find_by(tournament: pairing[real_player_id].tournament, name: "Bye")
+        end
+        Matchup.create!(round_number: round, player1: pairing[real_player_id], player2: bye)
       else
         Matchup.create!(round_number: round, player1: pairing[0], player2: pairing[1])
       end

--- a/app/controllers/players_controller.rb
+++ b/app/controllers/players_controller.rb
@@ -11,6 +11,21 @@ class PlayersController < ApplicationController
     end
 
     if @player.save
+      current_round = @tournament.players.first.win_count.to_i + @tournament.players.first.loss_count.to_i + 1
+      division_size = @tournament.players.count { |player| player.division == @player.division && player.name != "Bye" }
+      if division_size.odd?
+        bye = Player.create!(name: "Bye", tournament: @tournament, rating: 0, division: @player.division, win_count: 0)
+        Matchup.create!(round_number: current_round, player1: @player, player2: bye)
+      else
+        # find which player has a bye
+        matchups = @tournament.matchups.select { |matchup| matchup.player2.name == "Bye" && matchup.round_number >= current_round }
+        matchups.each do |matchup|
+          matchup.player2 = @player
+          matchup.save
+        end
+      end
+
+      Matchup.create()
       redirect_to edit_tournament_path(@tournament)
     else
       render 'tournaments/edit', status: :unprocessable_entity

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -72,7 +72,7 @@ class TournamentsController < ApplicationController
     # each value is an array of the players in that division
     @players = {}
     divisions.each do |div|
-      @players[div] = Player.where(tournament: @tournament, division: div).order(win_count: :desc, loss_count: :asc, spread: :desc).to_a
+      @players[div] = Player.where(tournament: @tournament, division: div).where.not(name: "Bye").order(win_count: :desc, loss_count: :asc, spread: :desc).to_a
     end
 
     # @event = Event.find(params[:tournament][:event])c

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -231,8 +231,8 @@ class TournamentsController < ApplicationController
       pairings.each do |pairing|
         if pairing.include?(Swissper::Bye)
           real_player_id = 1 - pairing.find_index(Swissper::Bye)
-          # bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div)
-          # Matchup.create!(round_number: 1, player1: pairing[real_player_id], player2: bye)
+          bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div)
+          Matchup.create!(round_number: 1, player1: pairing[real_player_id], player2: bye)
         else
           Matchup.create!(round_number: 1, player1: pairing[0], player2: pairing[1])
         end
@@ -244,8 +244,9 @@ class TournamentsController < ApplicationController
       pairings.each do |pairing|
         if pairing.include?(Swissper::Bye)
           real_player_id = 1 - pairing.find_index(Swissper::Bye)
+          bye = Player.find_by(tournament: tournament, name: "Bye")
           # bye = Player.create!(name: "Bye", tournament: tournament, rating: 0, division: div, win_count: 0)
-          # Matchup.create!(round_number: 2, player1: pairing[real_player_id], player2: bye)
+          Matchup.create!(round_number: 2, player1: pairing[real_player_id], player2: bye)
         else
           Matchup.create!(round_number: 2, player1: pairing[0], player2: pairing[1])
         end

--- a/app/views/tournaments/edit.html.erb
+++ b/app/views/tournaments/edit.html.erb
@@ -37,27 +37,29 @@
           <div class="tourney-no-players">No players added yet in Pairwise</div>
         <% else %>
           <% @tournament.players.each do |player| %>
-            <tr class="text-primary table-text">
-              <td class="d-flex gap-2 align-items-center text-left">
-                <% if player.photo.attached? %>
-                  <%= cl_image_tag player.photo.key,
-                    transformation: [
-                      {gravity: "face", height: 48, width: 48, crop: "thumb"},
-                      {radius: "max"},
-                      {background: "#e6e9ef"}
-                    ]
-                  %>
-                <% else %>
-                  <%= image_tag "user-astronaut-solid.svg", class: "matchup-avatar" %>
-                <% end %>
-                <%= player.name %>
-              </td>
-              <td class="text-center"><%= player.rating %></td>
-              <td class="text-center"><%= player.division %></td>
-              <td class="text-center"><%= player.seed %></td>
-              <td class="text-center"><%= player.ranking %></td>
-              <td class="text-center"><%= player.crosstables_id %></td>
-            </tr>
+            <% unless player.name == "Bye" %>
+              <tr class="text-primary table-text">
+                <td class="d-flex gap-2 align-items-center text-left">
+                  <% if player.photo.attached? %>
+                    <%= cl_image_tag player.photo.key,
+                      transformation: [
+                        {gravity: "face", height: 48, width: 48, crop: "thumb"},
+                        {radius: "max"},
+                        {background: "#e6e9ef"}
+                      ]
+                    %>
+                  <% else %>
+                    <%= image_tag "user-astronaut-solid.svg", class: "matchup-avatar" %>
+                  <% end %>
+                  <%= player.name %>
+                </td>
+                <td class="text-center"><%= player.rating %></td>
+                <td class="text-center"><%= player.division %></td>
+                <td class="text-center"><%= player.seed %></td>
+                <td class="text-center"><%= player.ranking %></td>
+                <td class="text-center"><%= player.crosstables_id %></td>
+              </tr>
+            <% end %>
           <% end %>
         <% end %>
       </tbody>


### PR DESCRIPTION
When you add a new player, it will now generate a matchup for them
When a tournament has an odd number of players, it will generate a bye for them and display it only on the "next game: bye" section on the scoreboard and on the pairings page.

![image](https://user-images.githubusercontent.com/31965238/204858537-7d380bcf-6deb-45d5-91a0-64aa5832904c.png)
![image](https://user-images.githubusercontent.com/31965238/204858685-6cc21ec8-09b1-4818-839f-1e5dfb8104c5.png)
![image](https://user-images.githubusercontent.com/31965238/204858817-d36b2772-002e-4b31-9ce9-18b5a0e7bfd5.png)

