### PR TITLE
Fix overflow bug on tournament cards when location is long

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,10 +1,3 @@
-/*
-TODO: Flesh these out. The event-card and tournament-card classes are used on
-the index page. The tournaments-card is also used on the My Tournaments
-page. These currently share most styles, but that can (and probably should
-be) overwritten.
-*/
-
 // Style shared by all card types
 .tournament-card, .event-card {
   border-radius: 14px;
@@ -21,8 +14,6 @@ be) overwritten.
 
 // Custom styling for event cards
 .event-card {
-  // height: 140px;
-  // border: 1px solid $dark_blue;
   padding: 20px;
   font-size: 14px;
   color: $dark_blue;
@@ -54,7 +45,7 @@ be) overwritten.
 .tournament-card {
   padding-top: 40px;
   padding-left: 40px;
-  height: 260px;
+  min-height: 260px;
   margin-bottom: 10px;
 }
 
@@ -62,7 +53,6 @@ be) overwritten.
 .tournaments, .my-tournaments {
   background-image: url(space-background.jpg);
   background-repeat: repeat;
-  // min-width: 100vh;
   background-size: 1000px;
 }
 
@@ -71,22 +61,8 @@ be) overwritten.
   padding-bottom: 3rem;
 }
 
-// TODO: This is a bootstrap class. Please define a different class if you need
-//       to use these styles somewhere.
-// .my-2 {
-//   font-size: 60px;
-//   color: white;
-//   font-weight: 600;
-//   text-shadow: $gray 1px 0 10px; // This makes the text blurry/hard to read
-// }
-
-// .container {
-//   padding-right: 50px;
-// }
-
 .col-lg {
-  float: left;
-  width: 60%;
+  width: 65%;
 }
 
 .tournament-date {
@@ -107,10 +83,6 @@ be) overwritten.
   font-weight: 400;
 }
 
-// p {
-//   margin-bottom: 5px;
-// }
-
 .tournament-powered {
   color: $gray;
   font-size: 16px;
@@ -121,18 +93,8 @@ be) overwritten.
   margin-top: 25px;
 }
 
-.players {
-  float: left;
-  margin-right: 80px;
-}
-
 .tournament-big-num {
   font-size: 75px;
   color: $dark_blue;
   text-align: center;
-  // text-shadow: $gray 1px 0 10px; // This makes the text blurry/hard to read
-}
-
-.games {
-  float: left;
 }

--- a/app/views/tournaments/_tournament.html.erb
+++ b/app/views/tournaments/_tournament.html.erb
@@ -1,13 +1,13 @@
 <div class="col-12 p-2">
   <%= link_to tournament_path(tournament), class: "text-decoration-none" do %>
-    <div class="tournament-card">
-      <div class="col-lg">
+    <div class="tournament-card d-flex">
+      <div class="col-lg flex-fill align-items-center">
         <h3 class="tournament-date"><%= tournament.event.date.strftime('%A, %b %e, %Y') %></h3>
         <h2 class="tournament-location"><%= tournament.event.location %></h2>
         <p class="tournament-rated">Rated by <em>NASPA©</em></p>
         <p class="tournament-powered">Powered by <em>PairWise</em></p>
       </div>
-      <div class="col-sm players">
+      <div class="col-sm flex-fill">
         <h4 class="tournament-head-cat"># PLAYERS</h4>
         <p class="tournament-big-num"><%=
           tournament.players.count ||
@@ -15,7 +15,7 @@
           "0"
         %></p>
       </div>
-      <div class="col-sm games">
+      <div class="col-sm flex-fill">
         <h4 class="tournament-head-cat"># GAMES</h4>
         <p class="tournament-big-num"><%= tournament.event.rounds %></p>
       </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/48395382/204907567-2713027f-554f-4909-a10c-e4a270d6a885.png)

This also (mostly) fixes the problem where narrow viewports would break the card

![image](https://user-images.githubusercontent.com/48395382/204907643-7fbb8ac2-7f88-4886-b108-b5cd900c6f29.png)
